### PR TITLE
Preempt breakage

### DIFF
--- a/JerryScript.lua
+++ b/JerryScript.lua
@@ -10,6 +10,8 @@
     thx to Sai, ren, aaron, Nowry, JayMontana, IceDoomfist and scriptCat and everyone else that helped me in #programming :)
 ]]
 
+pluto_use "0.5.0"
+
 local LOADING_START = util.current_time_millis()
 LOADING_SCRIPT = true
 
@@ -2514,7 +2516,7 @@ do
             ['Silent'] = 'MINITANK',
             ['Electric'] = 'CYCLONE',
         }
-        JSlang.slider_text(_LR['Vehicle sounds'], 'Engine sound', {'JSengineSound'}, '', {'Default', 'Silent', 'Electric'}, function(index, value)
+        JSlang.textslider_stateful(_LR['Vehicle sounds'], 'Engine sound', {'JSengineSound'}, '', {'Default', 'Silent', 'Electric'}, function(index, value)
             AUDIO._FORCE_VEHICLE_ENGINE_AUDIO(entities.get_user_vehicle_as_handle(), if type(car_sounds[value]) == 'string' then car_sounds[value] else car_sounds[value]())
         end)
 

--- a/lib/JSlangLib.lua
+++ b/lib/JSlangLib.lua
@@ -226,8 +226,8 @@ function JSlang.action_slider(root, name, link, description, ...)
     return menu.action_slider(root, JSlang.trans(name), link, JSlang.trans(description), ...)
 end
 
-function JSlang.slider_text(root, name, tableCommands, description, ...)
-    return menu.slider_text(root, JSlang.trans(name), tableCommands, JSlang.trans(description), ...)
+function JSlang.textslider_stateful(root, name, tableCommands, description, ...)
+    return menu.textslider_stateful(root, JSlang.trans(name), tableCommands, JSlang.trans(description), ...)
 end
 
 return JSlang


### PR DESCRIPTION
- Added `pluto_use "0.5.0"` so keywords are locked in at that Pluto version, preventing interference from new keywords, e.g. `new`, which you use as a variable name.
- Updated deprecated calls to `menu.slider_text` to use the replacement `menu.textslider_stateful` instead